### PR TITLE
Inject CI configs into migrated collection repos

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -698,6 +698,20 @@ def inject_readme_into_collection(collection_dir, *, ctx):
     )
 
 
+def inject_github_actions_workflow_into_collection(collection_dir, *, ctx):
+    """Insert GitHub Actions Workflow config into collection repo."""
+    target_file = 'collection-continuous-integration.yml'
+
+    workflows_dir = os.path.join(collection_dir, '.github', 'workflows')
+    os.makedirs(workflows_dir, exist_ok=True)
+
+    render_template_into(
+        f'{target_file}.tmpl',
+        ctx,
+        os.path.join(workflows_dir, target_file),
+    )
+
+
 def inject_gitignore_into_collection(collection_dir):
     """Insert a ``.gitignore`` file into the collection dir.
 
@@ -1146,6 +1160,10 @@ def assemble_collections(checkout_path, spec, args, target_github_org):
 
             inject_gitignore_into_collection(collection_dir)
             inject_readme_into_collection(
+                collection_dir,
+                ctx={'coll_ns': namespace, 'coll_name': collection},
+            )
+            inject_github_actions_workflow_into_collection(
                 collection_dir,
                 ctx={'coll_ns': namespace, 'coll_name': collection},
             )

--- a/migrate.py
+++ b/migrate.py
@@ -33,6 +33,7 @@ from baron.parser import ParsingError
 import redbaron
 
 from gh import GitHubOrgClient
+from template_utils import render_template_into
 
 
 # https://github.com/ansible/ansible/blob/100fe52860f45238ee8ca9e3019d1129ad043c68/hacking/fix_test_syntax.py#L62
@@ -683,6 +684,20 @@ def inject_init_into_tree(target_dir):
         write_text_into_file(initpath, '')
 
 
+def inject_readme_into_collection(collection_dir, *, ctx):
+    """Insert a ``README.md`` file into the collection dir.
+
+    The ``README.md.tmpl`` resource template file contains a title
+    and a GitHub Actions Workflow badge.
+    """
+    target_file = 'README.md'
+    render_template_into(
+        f'{target_file}.tmpl',
+        ctx,
+        os.path.join(collection_dir, target_file),
+    )
+
+
 def inject_gitignore_into_collection(collection_dir):
     """Insert a ``.gitignore`` file into the collection dir.
 
@@ -1130,6 +1145,10 @@ def assemble_collections(checkout_path, spec, args, target_github_org):
                 integration_tests_deps = set()
 
             inject_gitignore_into_collection(collection_dir)
+            inject_readme_into_collection(
+                collection_dir,
+                ctx={'coll_ns': namespace, 'coll_name': collection},
+            )
 
             # write collection metadata
             write_yaml_into_file_as_is(
@@ -1162,7 +1181,7 @@ def init_galaxy_metadata(collection, namespace, target_github_org):
         'namespace': namespace,
         'name': collection,
         'version': '1.0.0',  # TODO: add to spec, args?
-        'readme': None,
+        'readme': 'README.md',
         'authors': None,
         'description': None,
         'license': None,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 ansible
 gidgethub  # dependency of octomachinery but imported too
+Jinja2
 logzero
 octomachinery
 redbaron

--- a/resources/README.md.tmpl
+++ b/resources/README.md.tmpl
@@ -1,0 +1,4 @@
+[![GitHub Actions CI/CD build status — Collection test suite](https://github.com/{{ coll_ns }}/{{ coll_name }}/workflows/Collection%20test%20suite/badge.svg)](https://github.com/{{ coll_ns }}/{{ coll_name }}/actions?query=workflow%3A%22Collection%20test%20suite%22)
+
+Ansible Collection: {{ coll_ns }}.{{ coll_name }}
+=================================================

--- a/resources/collection-continuous-integration.yml.tmpl
+++ b/resources/collection-continuous-integration.yml.tmpl
@@ -1,0 +1,175 @@
+{% raw %}name: Collection test suite
+
+on:
+  push:
+  pull_request:
+  schedule:
+  - cron: 3 0 * * *  # Run daily at 0:03 UTC
+
+jobs:
+  build-collection-artifact:
+    name: Build collection
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+        - ubuntu-latest
+        python-version:
+        - 3.7
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Uninstall previously installed Ansible via Apt
+      run: sudo apt remove --yes ansible
+    - name: Uninstall previously installed Ansible via Pip
+      run: python -m pip uninstall ansible
+    - name: Install migration script deps
+      run: python -m pip install -r requirements.txt
+    - name: Install Ansible==devel
+      run: >-
+        python -m
+        pip
+        install
+        git+https://github.com/ansible/ansible.git@devel
+    - name: Build a collection tarball
+      run: >-
+        ansible-galaxy
+        collection
+        build
+        --output-path
+        "${GITHUB_WORKSPACE}/.cache/collection-tarballs"
+    - name: Store migrated collection artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: >-
+          collection-${{ matrix.os }}-${{ matrix.python-version }}
+        path: .cache/collection-tarballs
+
+  sanity-test-collection:
+    name: Run sanity tests in collections
+    needs:
+    - build-collection-artifact
+    runs-on: ${{ matrix.os.vm }}
+    container: ${{ matrix.os.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ansible-version:
+        - 2.9
+        - git+https://github.com/ansible/ansible.git@devel
+        os:
+        - vm: ubuntu-latest
+        - vm: ubuntu-16.04
+        - vm: macos-latest
+        - vm: ubuntu-latest
+          image: quay.io/ansible/default-test-container:1.10.1
+        - vm: ubuntu-latest
+          image: quay.io/ansible/fedora30-test-container:1.9.2
+        python-version:
+        - 3.8
+        - 3.7
+        - 3.6
+        - 3.5
+        - 2.7
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Uninstall previously installed Ansible via Apt
+      run: sudo apt remove --yes ansible
+    - name: Uninstall previously installed Ansible via Pip
+      run: python -m pip uninstall ansible
+    - name: Install Ansible ${{ matrix.ansible-version }}
+      run: >-
+        python -m
+        pip
+        install
+        ${{ matrix.ansible-version }}
+    - name: Download migrated collection artifacts
+      uses: actions/download-artifact@v1
+      with:
+        name: >-
+          collection-${{ matrix.os }}-${{ matrix.python-version }}
+        path: .cache/collection-tarballs
+    - name: Install the collection tarball
+      run: >-
+        ansible-galaxy
+        collection
+        install
+        .cache/collection-tarballs/*.tar.gz
+    - name: Run collection sanity tests
+      run: >-
+        ansible-test
+        sanity
+        --requirements
+        --python
+        "${{ matrix.python-version }}"
+        -vvv
+      working-directory: >-
+        ~/.ansible/collections/ansible_collections/{% endraw %}{{ coll_ns }}/{{ coll_name }}{% raw %}
+
+  unit-test-collection:
+    name: Run unit tests in collections
+    needs:
+    - build-collection-artifact
+    runs-on: ${{ matrix.os.vm }}
+    container: ${{ matrix.os.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ansible-version:
+        - 2.9
+        - git+https://github.com/ansible/ansible.git@devel
+        os:
+        - vm: ubuntu-latest
+        - vm: ubuntu-16.04
+        - vm: macos-latest
+        - vm: ubuntu-latest
+          image: quay.io/ansible/default-test-container:1.10.1
+        - vm: ubuntu-latest
+          image: quay.io/ansible/fedora30-test-container:1.9.2
+        python-version:
+        - 3.8
+        - 3.7
+        - 3.6
+        - 3.5
+        - 2.7
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Uninstall previously installed Ansible via Apt
+      run: sudo apt remove --yes ansible
+    - name: Uninstall previously installed Ansible via Pip
+      run: python -m pip uninstall ansible
+    - name: Install Ansible ${{ matrix.ansible-version }}
+      run: >-
+        python -m
+        pip
+        install
+        ${{ matrix.ansible-version }}
+    - name: Download migrated collection artifacts
+      uses: actions/download-artifact@v1
+      with:
+        name: >-
+          collection-${{ matrix.os }}-${{ matrix.python-version }}
+        path: .cache/collection-tarballs
+    - name: Install the collection tarball
+      run: >-
+        ansible-galaxy
+        collection
+        install
+        .cache/collection-tarballs/*.tar.gz
+    - name: Run collection unit tests
+      run: |
+        [[ ! -d 'tests/unit' ]] && echo This collection does not have unit tests. Skipping... || \
+        ansible-test units --requirements --python "${{ matrix.python-version }}" -vvv
+      working-directory: >-
+        ~/.ansible/collections/ansible_collections/{% endraw %}{{ coll_ns }}/{{ coll_name }}

--- a/template_utils.py
+++ b/template_utils.py
@@ -1,0 +1,11 @@
+"""Helpers for working with Jinja2 templates."""
+from pathlib import Path
+
+from jinja2 import Template
+
+
+def render_template_into(template_path: str, context: dict, target_path: str):
+    """Render the template on a given path."""
+    template_content = (Path('resources') / template_path).read_text()
+    rendered_content = Template(template_content).render(context)
+    Path(target_path).write_text(rendered_content)


### PR DESCRIPTION
This change adds a GitHub Actions CI Workflow config into each repo with a migrated collection.
It also adds badges pointing to CI pages of those repos on GitHub.