### PR TITLE
Move ipmi out of the minimal set

### DIFF
--- a/scenarios/minimal/ansible.yml
+++ b/scenarios/minimal/ansible.yml
@@ -155,8 +155,6 @@ _core:
     - packaging/os/rpm_key.py
     - packaging/os/yum.py
     - packaging/os/yum_repository.py
-    - remote_management/ipmi/ipmi_boot.py
-    - remote_management/ipmi/ipmi_power.py
     - source_control/git.py
     - source_control/subversion.py
     - system/cron.py

--- a/scenarios/minimal/misc.yml
+++ b/scenarios/minimal/misc.yml
@@ -2141,6 +2141,8 @@ glob:
     - remote_management/imc/__init__.py
     - remote_management/imc/imc_rest.py
     - remote_management/intersight/*
+    - remote_management/ipmi/ipmi_boot.py
+    - remote_management/ipmi/ipmi_power.py
     - remote_management/lxca/__init__.py
     - remote_management/lxca/lxca_cmms.py
     - remote_management/lxca/lxca_nodes.py


### PR DESCRIPTION
Community module.  Doesn't seem like it is a core responsibility?