### PR TITLE
Allow user more control where to git clone ansible

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -1876,6 +1876,8 @@ def main():
                         help='force refreshing local Ansible checkout')
     parser.add_argument('-t', '--target-dir', dest='vardir', default=VARDIR,
                         help='target directory for resulting collections and rpm')
+    parser.add_argument('--clone-directory', dest='clone_dir', default=False,
+                        help='The name of a new directory to git clone into')
     parser.add_argument('-p', '--preserve-module-subdirs', action='store_true', dest='preserve_module_subdirs', default=False,
                         help='preserve module subdirs per spec')
     parser.add_argument(
@@ -1938,7 +1940,11 @@ def main():
             raise
 
     releases_dir = os.path.join(args.vardir, 'releases')
-    devel_path = os.path.join(releases_dir, f'{DEVEL_BRANCH}.git')
+
+    if args.clone_dir:
+        devel_path = args.clone_dir
+    else:
+        devel_path = os.path.join(releases_dir, f'{DEVEL_BRANCH}.git')
 
     global ALL_THE_FILES
     ALL_THE_FILES = checkout_repo(DEVEL_URL, devel_path, refresh=args.refresh)


### PR DESCRIPTION
In CI, it is possible for the git repos to already exist on disk,
in a specific location. For example:

`~/src/github.com/ansible/ansible`

This patch, allows a user to now pass the following:

```console
python3.7 -m migrate -s ~/src/github.com/ansible-network/network_collections_migration/scenarios/arista --clone-directory ~/src/github.com/ansible/ansible/
```

And use an existing checked out version of ansible.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>