### PR TITLE
Set explicit_start=True when rewriting yaml file

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -188,7 +188,8 @@ def write_yaml_into_file_as_is(path, data):
 
 
 def write_ansible_yaml_into_file_as_is(path, data):
-    yaml_text = yaml.dump(data, Dumper=AnsibleDumper, allow_unicode=True, default_flow_style=False, sort_keys=False)
+    yaml_text = yaml.dump(
+        data, Dumper=AnsibleDumper, allow_unicode=True, default_flow_style=False, sort_keys=False, explicit_start=True)
     write_text_into_file(path, yaml_text)
 
 


### PR DESCRIPTION
After running the migration script on tests folder, our yamllint -s
failed, due to the migration tool removing '---' from the begining of
yaml files.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>