### PR TITLE
Also migrate deprecated content

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -1093,16 +1093,6 @@ def assemble_collections(checkout_path, spec, args, target_github_org):
                     relative_src_plugin_path = os.path.join(src_plugin_base, plugin)
                     src = os.path.join(checkout_path, relative_src_plugin_path)
 
-                    if os.path.basename(plugin).startswith('_') and os.path.basename(plugin) != '__init__.py':
-                        if os.path.islink(src):
-                            logger.info("Removing plugin alias from checkout and skipping: %s (%s in %s.%s)",
-                                         plugin, plugin_type, namespace, collection)
-                            remove(src)
-                        else:
-                            logger.error("We should not be migrating deprecated plugins, skipping: %s (%s in %s.%s)",
-                                         plugin, plugin_type, namespace, collection)
-                        continue
-
                     remove(src)
 
                     if plugin_type in ('modules',) and '/' in plugin:


### PR DESCRIPTION
The next release of ansible will be 2.10.0, talking with gundalow 2.13.0
was an option for when a collection could drop this content.

Fixes: #187
Signed-off-by: Paul Belanger <pabelanger@redhat.com>