### PR TITLE
🎨 Switch to using a GitHub Action for ssh-agent

### DIFF
--- a/.github/workflows/collection-migration-tests.yml
+++ b/.github/workflows/collection-migration-tests.yml
@@ -38,18 +38,14 @@ jobs:
       run: |
         git config --global user.email "ansible_migration@example.com"
         git config --global user.name "Poor B"
-    # https://www.webfactory.de/blog/use-ssh-key-for-private-repositories-in-github-actions
-    - name: Setup SSH Keys and known_hosts
+    - name: Add private SSH key to the agent
       if: >-
         github.event_name != 'pull_request'
         && github.repository == 'ansible-community/collection_migration'
-      env:
-        SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-      run: |
-        mkdir -p ~/.ssh
-        ssh-keyscan github.com >> ~/.ssh/known_hosts
-        ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-        ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY_MINIMAL }}"
+      # NOTE: ONLY BUMP THE VERSION AFTER CHECKING THE DIFF / SECURITY REVIEW
+      uses: webfactory/ssh-agent@v0.1.1
+      with:
+        ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_MINIMAL }}
     - name: >-
         Run migration scenario ${{ matrix.migration-scenario }}
         and auto-publish the migrated repos to GitHub repos
@@ -59,7 +55,6 @@ jobs:
       env:
         GITHUB_APP_IDENTIFIER: 41435
         GITHUB_PRIVATE_KEY: ${{ secrets.GITHUB_PRIVATE_KEY }}
-        SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       run: >-
         python -m
         migrate


### PR DESCRIPTION
This change refactors a copy-pasted snippet by removing it 🔥
from the workflow in favor of the reusable Action.

It also drops the explicit declaration of `SSH_AUTH_SOCK` env var
as the Action automatically exports it under the hood.