### PR TITLE
Fix regression for vars/keywords rewrites

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -1752,7 +1752,7 @@ def _rewrite_yaml_mapping(el, namespace, collection, spec, args, dest):
     assert isinstance(el, Mapping)
 
     _rewrite_yaml_mapping_keys_vars(el, namespace, collection, spec, args, dest)
-    _rewrite_yaml_mapping_keys_non_vars(el, namespace, collection, spec, args)
+    _rewrite_yaml_mapping_keys_non_vars(el, namespace, collection, spec, args, dest)
     _rewrite_yaml_mapping_values(el, namespace, collection, spec, args, dest)
 
 
@@ -1765,7 +1765,7 @@ KEYWORDS_TO_PLUGIN_MAP = {
 }
 
 
-def _rewrite_yaml_mapping_keys_non_vars(el, namespace, collection, spec, args):
+def _rewrite_yaml_mapping_keys_non_vars(el, namespace, collection, spec, args, dest):
     translate = []
     for key in el.keys():
         if key not in KEYWORDS_TO_PLUGIN_MAP and is_reserved_name(key):
@@ -1814,13 +1814,13 @@ def _rewrite_yaml_mapping_keys_non_vars(el, namespace, collection, spec, args):
 
         plugin_type = KEYWORDS_TO_PLUGIN_MAP.get(key)
         if plugin_type is not None:
-            _rewrite_yaml_mapping_value(namespace, collection, el, key, plugin_type, spec, args)
+            _rewrite_yaml_mapping_value(namespace, collection, el, key, plugin_type, spec, args, dest)
 
     for new_key, old_key in translate:
         el[new_key] = el.pop(old_key)
 
 
-def _rewrite_yaml_mapping_value(namespace, collection, el, key, plugin_type, spec, args):
+def _rewrite_yaml_mapping_value(namespace, collection, el, key, plugin_type, spec, args, dest):
     try:
         plugin_namespace, plugin_collection = get_plugin_collection(el[key], plugin_type, spec)
     except LookupError:
@@ -1853,7 +1853,7 @@ def _rewrite_yaml_mapping_keys_vars(el, namespace, collection, spec, args, dest)
         plugin_type = VARNAMES_TO_PLUGIN_MAP.get(key)
         if plugin_type is None:
             continue
-        _rewrite_yaml_mapping_value(namespace, collection, el, key, plugin_type, spec, args)
+        _rewrite_yaml_mapping_value(namespace, collection, el, key, plugin_type, spec, args, dest)
 
 
 def _rewrite_yaml_mapping_values(el, namespace, collection, spec, args, dest):
@@ -1862,7 +1862,7 @@ def _rewrite_yaml_mapping_values(el, namespace, collection, spec, args, dest):
             if key == 'vars':
                 _rewrite_yaml_mapping_keys_vars(el[key], namespace, collection, spec, args, dest)
             if key != 'vars':
-                _rewrite_yaml_mapping_keys_non_vars(el[key], namespace, collection, spec, args)
+                _rewrite_yaml_mapping_keys_non_vars(el[key], namespace, collection, spec, args, dest)
         elif isinstance(value, list):
             for idx, item in enumerate(value):
                 if isinstance(item, Mapping):

--- a/migrate.py
+++ b/migrate.py
@@ -1823,20 +1823,22 @@ def _rewrite_yaml_mapping_keys_non_vars(el, namespace, collection, spec, args):
 def _rewrite_yaml_mapping_value(namespace, collection, el, key, plugin_type, spec, args):
     try:
         plugin_namespace, plugin_collection = get_plugin_collection(el[key], plugin_type, spec)
-        if plugin_collection in COLLECTION_SKIP_REWRITE:
-            return
-        new_plugin_name = get_plugin_fqcn(plugin_namespace, plugin_collection, el[key])
-
-        msg = 'Rewriting to %s' % new_plugin_name
-        if args.fail_on_core_rewrite:
-            raise RuntimeError(msg)
-
-        logger.debug(msg)
-        el[key] = new_plugin_name
-        integration_tests_add_to_deps((namespace, collection), (plugin_namespace, plugin_collection))
     except LookupError:
         if '{{' in el[key]:
             add_manual_check(key, el[key], dest)
+        return
+
+    if plugin_collection in COLLECTION_SKIP_REWRITE:
+        return
+    new_plugin_name = get_plugin_fqcn(plugin_namespace, plugin_collection, el[key])
+
+    msg = 'Rewriting to %s' % new_plugin_name
+    if args.fail_on_core_rewrite:
+        raise RuntimeError(msg)
+
+    logger.debug(msg)
+    el[key] = new_plugin_name
+    integration_tests_add_to_deps((namespace, collection), (plugin_namespace, plugin_collection))
 
 
 VARNAMES_TO_PLUGIN_MAP = {

--- a/migrate.py
+++ b/migrate.py
@@ -1751,15 +1751,12 @@ def _rewrite_yaml(contents, namespace, collection, spec, args, dest):
 def _rewrite_yaml_mapping(el, namespace, collection, spec, args, dest):
     assert isinstance(el, Mapping)
 
-    _rewrite_yaml_mapping_keys(el, namespace, collection, spec, args, dest)
+    _rewrite_yaml_mapping_keys_vars(el, namespace, collection, spec, args, dest)
     _rewrite_yaml_mapping_keys_non_vars(el, namespace, collection, spec, args)
     _rewrite_yaml_mapping_values(el, namespace, collection, spec, args, dest)
 
 
-KEYWORD_TO_PLUGIN_MAP = {
-    'ansible_become_method': 'become',
-    'ansible_connection': 'connection',
-    'ansible_shell_type': 'shell',
+KEYWORDS_TO_PLUGIN_MAP = {
     'become_method': 'become',
     'cache_plugin': 'cache',
     'connection': 'connection',
@@ -1771,7 +1768,7 @@ KEYWORD_TO_PLUGIN_MAP = {
 def _rewrite_yaml_mapping_keys_non_vars(el, namespace, collection, spec, args):
     translate = []
     for key in el.keys():
-        if is_reserved_name(key):
+        if key not in KEYWORDS_TO_PLUGIN_MAP and is_reserved_name(key):
             continue
 
         prefix = 'with_'
@@ -1815,42 +1812,53 @@ def _rewrite_yaml_mapping_keys_non_vars(el, namespace, collection, spec, args):
                     translate.append((new_module_name, key))
                     integration_tests_add_to_deps((namespace, collection), (ns, coll))
 
+        plugin_type = KEYWORDS_TO_PLUGIN_MAP.get(key)
+        if plugin_type is not None:
+            _rewrite_yaml_mapping_value(namespace, collection, el, key, plugin_type, spec, args)
+
     for new_key, old_key in translate:
         el[new_key] = el.pop(old_key)
 
 
-def _rewrite_yaml_mapping_keys(el, namespace, collection, spec, args, dest):
-    for key in el.keys():
-        if is_reserved_name(key):
-            continue
+def _rewrite_yaml_mapping_value(namespace, collection, el, key, plugin_type, spec, args):
+    try:
+        plugin_namespace, plugin_collection = get_plugin_collection(el[key], plugin_type, spec)
+        if plugin_collection in COLLECTION_SKIP_REWRITE:
+            return
+        new_plugin_name = get_plugin_fqcn(plugin_namespace, plugin_collection, el[key])
 
-        plugin_type = KEYWORD_TO_PLUGIN_MAP.get(key)
+        msg = 'Rewriting to %s' % new_plugin_name
+        if args.fail_on_core_rewrite:
+            raise RuntimeError(msg)
+
+        logger.debug(msg)
+        el[key] = new_plugin_name
+        integration_tests_add_to_deps((namespace, collection), (plugin_namespace, plugin_collection))
+    except LookupError:
+        if '{{' in el[key]:
+            add_manual_check(key, el[key], dest)
+
+
+VARNAMES_TO_PLUGIN_MAP = {
+    'ansible_become_method': 'become',
+    'ansible_connection': 'connection',
+    'ansible_shell_type': 'shell',
+}
+
+
+def _rewrite_yaml_mapping_keys_vars(el, namespace, collection, spec, args, dest):
+    for key in el.keys():
+        plugin_type = VARNAMES_TO_PLUGIN_MAP.get(key)
         if plugin_type is None:
             continue
-
-        try:
-            plugin_namespace, plugin_collection = get_plugin_collection(el[key], plugin_type, spec)
-            if plugin_collection in COLLECTION_SKIP_REWRITE:
-                continue
-            new_plugin_name = get_plugin_fqcn(plugin_namespace, plugin_collection, el[key])
-
-            msg = 'Rewriting to %s' % new_plugin_name
-            if args.fail_on_core_rewrite:
-                raise RuntimeError(msg)
-
-            logger.debug(msg)
-            el[key] = new_plugin_name
-            integration_tests_add_to_deps((namespace, collection), (plugin_namespace, plugin_collection))
-        except LookupError:
-            if '{{' in el[key]:
-                add_manual_check(key, el[key], dest)
+        _rewrite_yaml_mapping_value(namespace, collection, el, key, plugin_type, spec, args)
 
 
 def _rewrite_yaml_mapping_values(el, namespace, collection, spec, args, dest):
     for key, value in el.items():
         if isinstance(value, Mapping):
             if key == 'vars':
-                _rewrite_yaml_mapping_keys(el[key], namespace, collection, spec, args, dest)
+                _rewrite_yaml_mapping_keys_vars(el[key], namespace, collection, spec, args, dest)
             if key != 'vars':
                 _rewrite_yaml_mapping_keys_non_vars(el[key], namespace, collection, spec, args)
         elif isinstance(value, list):

--- a/migrate.py
+++ b/migrate.py
@@ -1812,9 +1812,8 @@ def _rewrite_yaml_mapping_keys_non_vars(el, namespace, collection, spec, args, d
                     translate.append((new_module_name, key))
                     integration_tests_add_to_deps((namespace, collection), (ns, coll))
 
-        plugin_type = KEYWORDS_TO_PLUGIN_MAP.get(key)
-        if plugin_type is not None:
-            _rewrite_yaml_mapping_value(namespace, collection, el, key, plugin_type, spec, args, dest)
+        if key in KEYWORDS_TO_PLUGIN_MAP:
+            _rewrite_yaml_mapping_value(namespace, collection, el, key, KEYWORDS_TO_PLUGIN_MAP[key], spec, args, dest)
 
     for new_key, old_key in translate:
         el[new_key] = el.pop(old_key)

--- a/migrate.py
+++ b/migrate.py
@@ -1849,10 +1849,8 @@ VARNAMES_TO_PLUGIN_MAP = {
 
 def _rewrite_yaml_mapping_keys_vars(el, namespace, collection, spec, args, dest):
     for key in el.keys():
-        plugin_type = VARNAMES_TO_PLUGIN_MAP.get(key)
-        if plugin_type is None:
-            continue
-        _rewrite_yaml_mapping_value(namespace, collection, el, key, plugin_type, spec, args, dest)
+        if key in VARNAMES_TO_PLUGIN_MAP:
+            _rewrite_yaml_mapping_value(namespace, collection, el, key, VARNAMES_TO_PLUGIN_MAP[key], spec, args, dest)
 
 
 def _rewrite_yaml_mapping_values(el, namespace, collection, spec, args, dest):


### PR DESCRIPTION
This is probably from the time we started to do rewrites based on detecting `vars:` keyword.

Fixes #196