### PR TITLE
🔥 Force-push to GitHub unconditionally

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -1365,78 +1365,31 @@ def publish_to_github(collections_target_dir, spec, github_api, rsa_key):
     logger.debug('Using SSH key %s...', rsa_key.public_openssh)
     with rsa_key.ssh_agent as ssh_agent:
         for collection_dir, repo_name in collection_paths_except_core:
-            git_repo_url = read_yaml_file(
+            galaxy_yml = read_yaml_file(
                 os.path.join(collection_dir, 'galaxy.yml'),
-            )['repository']
-            # Putting our newly generated stuff on top of what's on remote:
-            # Ref: https://demisx.github.io/git/rebase/2015/07/02/git-rebase-keep-my-branch-changes.html
-            git_pull_rebase_cmd = (
-                'git', 'pull',
-                '--allow-unrelated-histories',
-                '--rebase',
-                '--strategy', 'recursive',
-                # Refs:
-                # * https://stackoverflow.com/a/3443225/595220
-                # * https://dev.to/willamesoares/git-ours-or-theirs-part1-agh
-                # * https://dev.to/willamesoares/git-ours-or-theirs-part-2-d0o
-                '--strategy-option', 'theirs',
-                git_repo_url,
-                'master',
             )
-            # with contextlib.suppress(LookupError):
-            #     git_repo_url = github_api.get_git_repo_write_uri(repo_name)
+            git_repo_url = galaxy_yml['repository']
+            coll_home_url = galaxy_yml['repository']
             git_repo_url_repr = '...'.join((
                 git_repo_url[:5], git_repo_url[-5:],
             )) if not git_repo_url.startswith('git@') else git_repo_url
-            logger.debug(
-                'Using %s Git URL for push',
+            logger.info(
+                'Forcefully pushing the migrated collection `%s` '
+                'to GitHub org `%s` using `%s` Git URL for push',
+                repo_name,
+                github_api.github_org_name,
                 git_repo_url_repr,
             )
-            logger.info(
-                'Rebasing the migrated collection in '
-                'repo %s on top of the Git remote',
-                repo_name,
+            git_force_push_cmd = (
+                'git', 'push', '--force', git_repo_url, 'HEAD:master',
             )
-            logger.debug('Invoking `%s`...', ' '.join(git_pull_rebase_cmd))
             with github_api.tmp_deployment_key_for(repo_name):
-                try:
-                    ssh_agent.run(
-                        git_pull_rebase_cmd,
-                        cwd=collection_dir,
-                        check=True,
-                        text=True,
-                        stdin=subprocess.DEVNULL,
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.PIPE,
-                    )
-                except subprocess.CalledProcessError as proc_err:
-                    # Ref: https://github.com/git/git/commit/b97e187364990fb8410355ff8b4365d0e37bbbbe
-                    acceptable_endings = {
-                        'error: nothing to do',
-                        "fatal: couldn't find remote ref master",
-                    }
-                    proc_stderr = proc_err.stderr[:-1]  # stripping off LF
-                    has_acceptable_stderr = proc_stderr.endswith
-                    if not any(
-                        has_acceptable_stderr(o)
-                        for o in acceptable_endings
-                    ):
-                        logger.error(
-                            'stderr output of `%s` is: %s',
-                            git_pull_rebase_cmd, proc_stderr,
-                        )
-                        raise
-                logger.info('Pushing the migrated collection to the Git remote')
-                ssh_agent.check_call(
-                    ('git', 'push', '--force', git_repo_url, 'HEAD:master'),
-                    cwd=collection_dir,
-                )
-                logger.info(
-                    'The migrated collection has been successfully published to '
-                    '`https://github.com/%s/%s.git`...',
-                    github_api.github_org_name,
-                    repo_name,
-                )
+                ssh_agent.check_call(git_force_push_cmd, cwd=collection_dir)
+            logger.info(
+                'The migrated collection has been successfully published to '
+                '`%s` GitHub repository...',
+                coll_home_url,
+            )
 
 
 def push_migrated_core(releases_dir, github_api, rsa_key):


### PR DESCRIPTION
This change gets rid of trying to nicely rebase new migrated collection
on top of the old one. Git's porcelan is too nuanced, non-flexible and
non-deterministic. Using Git's plumbing is overkill. So just giving up.

This should also fix:
```console
2020-01-09T02:20:09.3557394Z [E 200109 02:20:09 migrate:1426] stderr output of `('git', 'pull', '--allow-unrelated-histories', '--rebase', '--strategy', 'recursive', '--strategy-option', 'theirs', 'git@github.com:ansible-collection-migration/misc.glob.git', 'master')` is: Failed to add the RSA host key for IP address '192.30.253.113' to the list of known hosts (/home/runner/.ssh/known_hosts).
2020-01-09T02:20:09.3559192Z     warning: no common commits
2020-01-09T02:20:09.3560740Z     From github.com:ansible-collection-migration/misc.glob
2020-01-09T02:20:09.3562049Z      * branch              master     -> FETCH_HEAD
2020-01-09T02:20:09.3563047Z     Rebasing (1/1)
2020-01-09T02:20:09.3565012Z     The previous cherry-pick is now empty, possibly due to conflict resolution.
2020-01-09T02:20:09.3566300Z     If you wish to commit it anyway, use:
2020-01-09T02:20:09.3567269Z     
2020-01-09T02:20:09.3568701Z         git commit --allow-empty
2020-01-09T02:20:09.3569643Z     
2020-01-09T02:20:09.3570765Z     Otherwise, please use 'git cherry-pick --skip'
2020-01-09T02:20:09.3571903Z     interactive rebase in progress; onto 65637336
2020-01-09T02:20:09.3572872Z     Last command done (1 command done):
2020-01-09T02:20:09.3573784Z        pick 5f0d4156 Initial commit
2020-01-09T02:20:09.3575092Z     No commands remaining.
2020-01-09T02:20:09.3576426Z     You are currently rebasing branch 'master' on '65637336'.
2020-01-09T02:20:09.3577529Z     
2020-01-09T02:20:09.3578464Z     nothing to commit, working tree clean
2020-01-09T02:20:09.3580341Z     Could not apply 5f0d4156... Initial commit
2020-01-09T02:20:09.6945037Z Traceback (most recent call last):
2020-01-09T02:20:09.6947435Z   File "/opt/hostedtoolcache/Python/3.7.5/x64/lib/python3.7/runpy.py", line 193, in _run_module_as_main
2020-01-09T02:20:09.6948482Z     "__main__", mod_spec)
2020-01-09T02:20:09.6953236Z   File "/opt/hostedtoolcache/Python/3.7.5/x64/lib/python3.7/runpy.py", line 85, in _run_code
2020-01-09T02:20:09.6954098Z     exec(code, run_globals)
2020-01-09T02:20:09.6955253Z   File "/home/runner/work/collection_migration/collection_migration/migrate.py", line 2075, in <module>
2020-01-09T02:20:09.6956149Z     main()
2020-01-09T02:20:09.6957006Z   File "/home/runner/work/collection_migration/collection_migration/migrate.py", line 2057, in main
2020-01-09T02:20:09.6958007Z     gh_api, tmp_rsa_key,
2020-01-09T02:20:09.6959094Z   File "/home/runner/work/collection_migration/collection_migration/migrate.py", line 1410, in publish_to_github
2020-01-09T02:20:09.6959973Z     stderr=subprocess.PIPE,
2020-01-09T02:20:09.6960833Z   File "/home/runner/work/collection_migration/collection_migration/rsa_utils.py", line 128, in method_wrapper
2020-01-09T02:20:09.6961677Z     return meth(self, *args, **kwargs)
2020-01-09T02:20:09.6962513Z   File "/home/runner/work/collection_migration/collection_migration/rsa_utils.py", line 152, in run
2020-01-09T02:20:09.6963467Z     return subprocess.run(*args, **kwargs)
2020-01-09T02:20:09.6964304Z   File "/opt/hostedtoolcache/Python/3.7.5/x64/lib/python3.7/subprocess.py", line 512, in run
2020-01-09T02:20:09.6965376Z     output=stdout, stderr=stderr)
2020-01-09T02:20:09.6967250Z subprocess.CalledProcessError: Command '('git', 'pull', '--allow-unrelated-histories', '--rebase', '--strategy', 'recursive', '--strategy-option', 'theirs', 'git@github.com:ansible-collection-migration/misc.glob.git', 'master')' returned non-zero exit status 1.
2020-01-09T02:20:09.7632508Z ##[error]Process completed with exit code 1.
```
_(https://github.com/ansible-community/collection_migration/runs/380561895)_