### PR TITLE
bcs: merge vmware_soap and vmware_rest

### DIFF
--- a/scenarios/bcs/ansible.yml
+++ b/scenarios/bcs/ansible.yml
@@ -1147,30 +1147,26 @@ unix:
     shell:
     - csh.py
     - fish.py
-vmware_soap:
+vmware:
     connection:
     - vmware_tools.py
     doc_fragments:
     - vmware.py
-    inventory:
-    - vmware_vm_inventory.py
-    modules:
-    - cloud/vmware/*
-    module_utils:
-    - vmware.py
-    - vmware_spbm.py
-vmware_rest:
-    doc_fragments:
     - vmware_rest_client.py
     - VmwareRestModule.py
     - VmwareRestModule_filters.py
     - VmwareRestModule_full.py
     - VmwareRestModule_state.py
+    inventory:
+    - vmware_vm_inventory.py
+    modules:
+    - cloud/vmware/*
+    - cloud/vmware_httpapi/*
     module_utils:
+    - vmware.py
+    - vmware_spbm.py
     - vmware_rest_client.py
     - vmware_httpapi/*
-    modules:
-    - cloud/vmware_httpapi/*
     httpapi:
     - vmware.py
 vultr:


### PR DESCRIPTION
We don't have any plan to provide two different collections for vmware
modules.