### PR TITLE
[NWO] Add archive

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -5,6 +5,7 @@ _core:
   - commands/raw.py
   - commands/script.py
   - commands/shell.py
+  - files/archive.py
   - files/blockinfile.py
   - files/copy.py
   - files/fetch.py


### PR DESCRIPTION
archive is used by several integration tests so it may be a good
candidate for inclusion in base.

However, it is currently community supported and wasn't originally
written by ansible.  It probably warrants discussion/decision by
someone other than me.