### PR TITLE
[NWO] Move the controller-side windows plugins into base

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -202,7 +202,9 @@ _core:
   - local.py
   - netconf.py
   - network_cli.py
+  - psrp.py
   - ssh.py
+  - winrm.py
   test:
   - core.py
   - files.py
@@ -315,6 +317,8 @@ _core:
   - pickle.py
   - yaml.py
   shell:
+  - cmd.py
+  - powershell.py
   - sh.py
 netcommon:
   modules:

--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -2552,11 +2552,9 @@ general:
   - oc.py
   - paramiko_ssh.py
   - podman.py
-  - psrp.py
   - qubes.py
   - saltstack.py
   - vmware_tools.py
-  - winrm.py
   - zone.py
   terminal:
   - aireos.py
@@ -2862,10 +2860,8 @@ general:
   - mongodb.py
   - redis.py
   shell:
-  - cmd.py
   - csh.py
   - fish.py
-  - powershell.py
   #scripts:
   #- contrib/inventory/abiquo.ini
   #- contrib/inventory/abiquo.py


### PR DESCRIPTION
We decided that windows modules would go into their own collections but
controller-side plugins would go into base.  This moves the windows and
connection and shell plugins into base to conform to that.