### PR TITLE
[NWO] Remove the host_pinned strategy from base

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -267,7 +267,6 @@ _core:
   strategy:
   - debug.py
   - free.py
-  - host_pinned.py
   - linear.py
   lookup:
   - config.py


### PR DESCRIPTION
It feels like free and host_pinned are close enough in functionality that most people should be encouraged to use one or te other and people who really need the differences can use the other one from a collection.  host_pinned is a community strategy plugin so it feels like the proper candidate for
removal from base.

Alternately, core could adopt host_pinned and remove free if they think that host_pinned is closer to what they want to support.