### PR TITLE
[NWO] Prune callbacks and strategy of non-essential plugins

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -213,13 +213,11 @@ _core:
   - urls.py
   - urlsplit.py
   callback:
-  - debug.py
   - default.py
   - junit.py
   - minimal.py
   - oneline.py
   - tree.py
-  - yaml.py
   action:
   - add_host.py
   - assert.py
@@ -265,7 +263,6 @@ _core:
   - su.py
   - sudo.py
   strategy:
-  - debug.py
   - free.py
   - host_pinned.py
   - linear.py


### PR DESCRIPTION
* Remove debug strategy.  Decided that plugins whose primary purpose is
  debugging and profiling are niche and thus do not belong in
  ansible-base.
* Remove debug and junit callback as these are niche.
* Remove the yaml callback as it isn't used to implement any command
  line features.