### PR TITLE
[NWO] Remove the memcached cache file plugin

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -311,7 +311,6 @@ _core:
   - yaml.py
   cache:
   - jsonfile.py
-  - memcached.py
   - memory.py
   - pickle.py
   - yaml.py


### PR DESCRIPTION
This has an external dependency and a memcached server isn't a feature
of all posix environments so it feels like it doesn't belong in
ansible-base