### PR TITLE
[NWO] Move timezone from base to community

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -59,7 +59,6 @@ _core:
   - system/setup.py
   - system/systemd.py
   - system/sysvinit.py
-  - system/timezone.py
   - system/user.py
   - utilities/helper/_accelerate.py
   - utilities/helper/meta.py


### PR DESCRIPTION
Although all posix systems we care about have a timezone, it's not the
most essential part of managing a posix system.  Mount, which we do not
include in base, would seem to be more important, for instance.  It
seems like it is on the edge, though, so someone else besides me should
probably also weigh in so we can have several opinions.