### PR TITLE
[NWO] Remove the patch module from base

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -11,7 +11,6 @@ _core:
   - files/file.py
   - files/find.py
   - files/lineinfile.py
-  - files/patch.py
   - files/replace.py
   - files/stat.py
   - files/tempfile.py
@@ -237,7 +236,6 @@ _core:
   - netconf.py
   - normal.py
   - package.py
-  - patch.py
   - pause.py
   - raw.py
   - reboot.py


### PR DESCRIPTION
Patch is a posix oriented module but it is community supported and not
very popular.  For instance, assemble (which we do not include) is more
frequently used in galaxy roles than patch.  This PR removes the module
and associated action plugin from base but I think it's on the edge of
what we want so we probably should get an opinion from someone besides
me before making a decision.

(Note: if we keep it, we may want to consider adding assemble as well)