### PR TITLE
[NWO] Move notification modules out of base

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -21,9 +21,6 @@ _core:
   - net_tools/basics/get_url.py
   - net_tools/basics/slurp.py
   - net_tools/basics/uri.py
-  - notification/irc.py
-  - notification/jabber.py
-  - notification/mail.py
   - packaging/language/pip.py
   - packaging/os/apt.py
   - packaging/os/apt_key.py


### PR DESCRIPTION
It feels like these are not essential to writing ansible playbooks so
they are beyond the scope of ansible-base.  Additional backup for that
view is that all of these modules are currently community support.