### PR TITLE
[NWO] Move ipmi modules out of base

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -40,8 +40,6 @@ _core:
   - packaging/os/rpm_key.py
   - packaging/os/yum.py
   - packaging/os/yum_repository.py
-  - remote_management/ipmi/ipmi_boot.py
-  - remote_management/ipmi/ipmi_power.py
   - source_control/git.py
   - source_control/subversion.py
   - system/cron.py


### PR DESCRIPTION
These are community modules which serve a niche use case.  Remove from
the base set.

This was approved once before here:

https://github.com/ansible-community/collection_migration/pull/159