### PR TITLE
NWO: Move paramiko_ssh back into base

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -192,6 +192,7 @@ _core:
   - yumdnf.py
   connection:
   - local.py
+  - paramiko_ssh.py
   - psrp.py
   - ssh.py
   - winrm.py

--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -2515,7 +2515,6 @@ general:
   - lxc.py
   - lxd.py
   - oc.py
-  - paramiko_ssh.py
   - podman.py
   - qubes.py
   - saltstack.py


### PR DESCRIPTION
This currently is a dependency for network_cli (which the network team
is looking to break), but we really don't want to include it into
ansible.netcommon. Rather then depending on ansible.community
collections, we already have a dependency on base.

We have discussed moving this into ansible.netcommon, if we do so we'd
mark this deprecated right away and work to remove it from
ansible.netcommon (this leaves potential issue for community folks still
using it).

This looks to be the lesser of two evils?

Signed-off-by: Paul Belanger <pabelanger@redhat.com>