### PR TITLE
NWO: Remove nxos bits from sensu collection

### DIFF
--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -432,6 +432,7 @@ general:
   - network/exos/facts/vlans/__init__.py
   - network/exos/facts/vlans/vlans.py
   - network/exos/utils/__init__.py
+  - network/exos/utils/utils.py
   - network/f5/__init__.py
   - network/f5/iworkflow.py
   - network/f5/legacy.py

--- a/scenarios/nwo/sensu.yml
+++ b/scenarios/nwo/sensu.yml
@@ -1,4 +1,3 @@
 sensu_go:
   module_utils:
   - network/exos/utils/utils.py
-  - network/nxos/utils/utils.py

--- a/scenarios/nwo/sensu.yml
+++ b/scenarios/nwo/sensu.yml
@@ -1,3 +1,0 @@
-sensu_go:
-  module_utils:
-  - network/exos/utils/utils.py


### PR DESCRIPTION
cisco.nxos is the only place this is needed.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>