### PR TITLE
NWO: Add module_utils/pycompat24.py back to base

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -231,6 +231,7 @@ _core:
   - powershell/Ansible.ModuleUtils.SID.psm1
   - powershell/Ansible.ModuleUtils.WebRequest.psm1
   - powershell/__init__.py
+  - pycompat24.py
   - service.py
   - six/*
   - splitter.py

--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -509,7 +509,6 @@ general:
   - podman/common.py
   - postgres.py
   - pure.py
-  - pycompat24.py
   - rabbitmq.py
   - rax.py
   - redfish_utils.py


### PR DESCRIPTION
This is because module_utils/basic.py depends on it, which is causing
ansible-galaxy colleciton install to fail.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>