### PR TITLE
NWO: Move compat/ipaddress.py into ansible.netcommon

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -351,6 +351,7 @@ netcommon:
   httpapi:
   - restconf.py
   module_utils:
+  - compat/ipaddress.py
   - network/common/*
   - network/common/*/*
   - network/netconf/*

--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -308,8 +308,6 @@ general:
   - cloud.py
   - cloudscale.py
   - cloudstack.py
-  - compat/__init__.py
-  - compat/ipaddress.py
   - crypto.py
   - database.py
   - digital_ocean.py


### PR DESCRIPTION
We have network collections (vyos.vyos) that depend on this code.  Since
specific to network, seems right to import into ansible.netcommon.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>