### PR TITLE
Revert "Incorrect YAML is handled in a caller (#314)"

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -1810,9 +1810,12 @@ def rewrite_ini_section(config, key_map, section, namespace, collection, spec, a
 
 
 def rewrite_yaml(src, dest, namespace, collection, spec, args, checkout_dir):
-    contents = read_ansible_yaml_file(src)
-    _rewrite_yaml(contents, namespace, collection, spec, args, dest, checkout_dir)
-    write_ansible_yaml_into_file_as_is(dest, contents)
+    try:
+        contents = read_ansible_yaml_file(src)
+        _rewrite_yaml(contents, namespace, collection, spec, args, dest, checkout_dir)
+        write_ansible_yaml_into_file_as_is(dest, contents)
+    except Exception as e:
+        logger.error('Skipping bad YAML in %s: %s', src, str(e))
 
 
 def _rewrite_yaml(contents, namespace, collection, spec, args, dest, checkout_dir):


### PR DESCRIPTION
By reverting, this should make CI green again. We can then enable branch
protections to help keep CI passing.

We then can propose a revert of this revert, and address any issue with
scenario files for nwo.

This reverts commit 5cf1fc8b997aacd5f241a56b3f1cf0bce888c438.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>