### PR TITLE
Add networking scenario for testing

### DIFF
--- a/scenarios/networking/ansible.yml
+++ b/scenarios/networking/ansible.yml
@@ -1,0 +1,1 @@
+../nwo/ansible.yml

--- a/scenarios/networking/arista.yml
+++ b/scenarios/networking/arista.yml
@@ -1,0 +1,1 @@
+../nwo/arista.yml

--- a/scenarios/networking/cisco.yml
+++ b/scenarios/networking/cisco.yml
@@ -1,0 +1,1 @@
+../nwo/cisco.yml

--- a/scenarios/networking/junipernetworks.yml
+++ b/scenarios/networking/junipernetworks.yml
@@ -1,0 +1,1 @@
+../nwo/junipernetworks.yml

--- a/scenarios/networking/vyos.yml
+++ b/scenarios/networking/vyos.yml
@@ -1,0 +1,1 @@
+../nwo/vyos.yml


### PR DESCRIPTION
This creates a smaller networking scenerio, based on nwo, for testing
the following:

    ansible.netcommon
    arista.eos
    cisco.ios
    cisco.iosxr
    cisco.nxos
    junipernetworks.junos
    vyos.vyos

Allow us to remove generating all other collections. This does mean
extra files left in ansible repo, but this is okay as we have another
job just to create ansible-base content.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>