### PR TITLE
Use ansible-galaxy from migrated ansible repo for testing

### DIFF
--- a/.github/workflows/collection-migration-tests.yml
+++ b/.github/workflows/collection-migration-tests.yml
@@ -97,6 +97,13 @@ jobs:
         --refresh "${{ env.CORE_REPO_REF }}"
         --skip-publish
         --convert-symlinks
+    - name: Build ansible tarball from scenario
+      run: |
+        mkdir -p "${GITHUB_WORKSPACE}/.cache/collection-tarballs/ansible/"
+        cd .cache/releases/devel.git
+        _ANSIBLE_SDIST_FROM_MAKEFILE=1 python setup.py sdist
+        mv dist/*.tar.gz "${GITHUB_WORKSPACE}/.cache/collection-tarballs/ansible/"
+        ls -la "${GITHUB_WORKSPACE}/.cache/collection-tarballs/ansible/"
     - name: Prepare user's SSH config dir
       run: |
         mkdir -p ~/.ssh
@@ -153,6 +160,9 @@ jobs:
     - name: >-
         Generate tarballs out of migrated collections, one by one
       run: |
+        python -m venv /tmp/ansible-${{matrix.migration-scenario}}-venv
+        source /tmp/ansible-${{matrix.migration-scenario}}-venv/bin/activate
+        pip install "${GITHUB_WORKSPACE}/.cache/collection-tarballs/ansible/ansible-2.10.0.dev0.tar.gz"
           for coll_dir in `ls .cache/collections/*/*/* -d`
           do
               (
@@ -162,6 +172,8 @@ jobs:
                   ansible-galaxy collection build --output-path "${GITHUB_WORKSPACE}/.cache/collection-tarballs"
               )
           done
+        deactivate
+        rm -rf /tmp/ansible-${{matrix.migration-scenario}}-venv
     - name: Store migrated collection artifacts
       uses: actions/upload-artifact@v1
       with:
@@ -202,15 +214,15 @@ jobs:
       run: sudo apt remove --yes ansible
     - name: Uninstall previously installed Ansible via Pip
       run: python -m pip uninstall ansible
-    - name: Install Ansible==devel
-      run: >-
-        python -m pip install git+https://github.com/ansible/ansible.git@devel
     - name: Download migrated collection artifacts
       uses: actions/download-artifact@v1
       with:
         name: >-
           migrated-collections-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.migration-scenario }}
         path: .cache/collection-tarballs
+    - name: Install Ansible==devel
+      run: >-
+        pip install "${GITHUB_WORKSPACE}/.cache/collection-tarballs/ansible/ansible-2.10.0.dev0.tar.gz"
     - name: >-
         Install the migrated collections
       run: |
@@ -266,15 +278,15 @@ jobs:
       run: sudo apt remove --yes ansible
     - name: Uninstall previously installed Ansible via Pip
       run: python -m pip uninstall ansible
-    - name: Install Ansible==devel
-      run: >-
-        python -m pip install git+https://github.com/ansible/ansible.git@devel
     - name: Download migrated collection artifacts
       uses: actions/download-artifact@v1
       with:
         name: >-
           migrated-collections-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.migration-scenario }}
         path: .cache/collection-tarballs
+    - name: Install Ansible==devel
+      run: >-
+        pip install "${GITHUB_WORKSPACE}/.cache/collection-tarballs/ansible/ansible-2.10.0.dev0.tar.gz"
     - name: >-
         Install the migrated collections
       run: |


### PR DESCRIPTION
We should use ansible-galaxy, from the ansible version migrated via
scenario files. This will allow for better smoke testing of
ansible-galaxy, and help catch breakages.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>