### PR TITLE
NWO: Move template_common doc fragment to ansible.

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -63,6 +63,7 @@ _core:
   - inventory_cache.py
   - return_common.py
   - shell_common.py
+  - template_common.py
   - url.py
   - validate.py
   - vars_plugin_staging.py

--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -207,7 +207,6 @@ general:
   - shell_windows.py
   - skydive.py
   - sros.py
-  - template_common.py
   - tower.py
   - url_windows.py
   - utm.py


### PR DESCRIPTION
The fragment is used by the template module, which is also in ansible.