### PR TITLE
NWO: Move shell_windows doc fragment to ansible.

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -64,6 +64,7 @@ _core:
   - inventory_cache.py
   - return_common.py
   - shell_common.py
+  - shell_windows.py
   - template_common.py
   - url.py
   - validate.py

--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -425,7 +425,6 @@ general:
   - rabbitmq.py
   - rackspace.py
   - scaleway.py
-  - shell_windows.py
   - skydive.py
   - sros.py
   - tower.py


### PR DESCRIPTION
The fragment is used by the cmd plugin, which is also in ansible.