### PR TITLE
NWO: Move cache base plugin back into ansible.

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -33,6 +33,7 @@ _core:
   - sudo.py
   cache:
   - __init__.py
+  - base.py
   - jsonfile.py
   - memory.py
   - pickle.py

--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -39,7 +39,6 @@ general:
   - runas.py
   - sesu.py
   cache:
-  - base.py
   - memcached.py
   - mongodb.py
   - redis.py


### PR DESCRIPTION
The base plugin is a backwards compatibility shim, not an actual plugin. Migrating it to a collection prevents the shim from performing its intended purpose.

If the backwards compatibility shim is no longer needed it should be removed from ansible instead of being migrated.