### PR TITLE
minor: ensure git does not GPG sign the commits

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -1405,7 +1405,7 @@ def assemble_collections(checkout_path, spec, args, target_github_org):
             subprocess.check_call(('git', 'init'), cwd=collection_dir)
             subprocess.check_call(('git', 'add', '.'), cwd=collection_dir)
             subprocess.check_call(
-                ('git', 'commit', '-m', 'Initial commit', '--allow-empty'),
+                ('git', 'commit', '-m', 'Initial commit', '--allow-empty', '--no-gpg-sign'),
                 cwd=collection_dir,
             )
 


### PR DESCRIPTION
By default, my git signs all my commit, and by default the gpg-agent cache the key
for =~ 600s.
If my key is not in the cache anymore and I'm not in front of my laptop, the
migration script just fail, by adding the `--no-gpg-sign`, I avoid the problem.