### PR TITLE
Do not process empty __init__.py's

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -1333,6 +1333,13 @@ def assemble_collections(checkout_path, spec, args, target_github_org):
                         # TODO: handle powershell import rewrites
                         shutil.copyfile(src, dest)
                         continue
+                    elif plugin_type in ('modules',) and src.endswith('__init__.py'):
+                        # __init__.py in lib/ansible/modules are empty so just copy them over
+                        # this saves us from doing all the processing on them and
+                        # also from giving false positives in unit tests discovery
+                        logger.info('Copying %s -> %s', src, dest)
+                        shutil.copyfile(src, dest)
+                        continue
 
                     logger.info('Processing %s -> %s', src, dest)
 

--- a/migrate.py
+++ b/migrate.py
@@ -1333,7 +1333,7 @@ def assemble_collections(checkout_path, spec, args, target_github_org):
                         # TODO: handle powershell import rewrites
                         shutil.copyfile(src, dest)
                         continue
-                    elif plugin_type in ('modules',) and src.endswith('__init__.py'):
+                    elif plugin_type == 'modules' and os.path.basename(src) == '__init__.py':
                         # __init__.py in lib/ansible/modules are empty so just copy them over
                         # this saves us from doing all the processing on them and
                         # also from giving false positives in unit tests discovery


### PR DESCRIPTION
1. they are empty, 2. doing unit tests discovery on files like `.cache/collections/ansible_collections/community/general/plugins/modules/__init__.py` gives some false positives:
```
[I 200211 09:28:48 migrate:879] Rewriting plugin references in .cache/collections/ansible_collections/community/general/plugins/modules/__init__.py
[I 200211 09:28:48 migrate:1055] Locating parent conftest.py for .cache/releases/devel.git/test/units/modules/network/__init__.py...
[I 200211 09:28:48 migrate:1070] Located .cache/releases/devel.git/test/units/modules/conftest.py...
> /home/mkrizek/src/collection_migration/migrate.py(1164)discover_file_migrations()
(Epdb) pp list(related_test_fixtures)
['test/units/modules/network/vyos/fixtures/vyos_config_config.cfg',
 'test/units/modules/network/vyos/fixtures/vyos_config_src_brackets.cfg',
 'test/units/modules/network/vyos/fixtures/show_host_name',
 'test/units/modules/network/vyos/test_vyos_command.py',
 'test/units/modules/network/vyos/test_vyos_facts.py',
 'test/units/modules/network/vyos/fixtures/vyos_ping_ping_10.10.10.10_count_2',
 'test/units/modules/network/vyos/fixtures/vyos_ping_ping_10.10.10.11_count_10_ttl_128_size_512',
 'test/units/modules/network/vyos/test_vyos_system.py',
 'test/units/modules/network/vyos/vyos_module.py',
 'test/units/modules/network/vyos/fixtures/vyos_config_src.cfg',
 'test/units/modules/network/vyos/test_vyos_user.py',
 'test/units/modules/network/vyos/test_vyos_banner.py',
 'test/units/modules/network/vyos/test_vyos_ping.py',
 'test/units/modules/network/vyos/fixtures/show_version',
 'test/units/modules/network/vyos/__init__.py',
 'test/units/modules/network/vyos/fixtures/vyos_user_config.cfg',
 'test/units/modules/network/vyos/test_vyos_static_route.py',
 'test/units/modules/network/vyos/test_vyos_config.py',
...
```