### PR TITLE
[NWO] Restore `debug` and `host_pinned` strategies.

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -319,7 +319,9 @@ _core:
   - sh.py
   strategy:
   - __init__.py
+  - debug.py
   - free.py
+  - host_pinned.py
   - linear.py
   terminal:
   - __init__.py

--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -2776,9 +2776,6 @@ general:
   shell:
   - csh.py
   - fish.py
-  strategy:
-  - debug.py
-  - host_pinned.py
   terminal:
   - aireos.py
   - apconos.py


### PR DESCRIPTION
Both of these strategy plugins are nothing but documentation. All functionality is implemented by the underlying `linear` and `free` strategies, and in the case of `debug`, by `lib/ansible/strategy/__init__.py` itself.

If we truly want to remove these plugins from ansible-base, the code should first be extracted from the base classes into the strategy plugins.

It's also worth noting that there are multiple integration tests for ansible-base that depend on both of these plugins.