### PR TITLE
NWO: move network_agnostic doc fragment into ansible.netcommon

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -347,6 +347,7 @@ netcommon:
   - persistent.py
   doc_fragments:
   - netconf.py
+  - network_agnostic.py
   filter:
   - network.py
   httpapi:

--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -448,7 +448,6 @@ general:
   - manageiq.py
   - mysql.py
   - netscaler.py
-  - network_agnostic.py
   - nios.py
   - nso.py
   - oneview.py


### PR DESCRIPTION
This is a shared doc fragment, it should live in ansible.netcommon not
community.general.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>