### PR TITLE
[NWO] Migrate tests for windows setup and slurp.

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -381,6 +381,11 @@ windows:
   - runas.py
   doc_fragments:
   - url_windows.py
+  integration:
+  - win_setup/*
+  - win_setup/*/*
+  - win_slurp/*
+  - win_slurp/*/*
   module_utils:
   - csharp/Ansible.Service.cs
   modules:


### PR DESCRIPTION
`windows/setup.ps1` and `windows/slurp.ps1` were already migrated to `ansible.windows`. However, since the tests are named with a `win_` prefix they were not migrated long with the modules.