### PR TITLE
[NWO] Promote win_wait_for into core

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -463,5 +463,7 @@ windows:
   - windows/win_user.py
   - windows/win_user_right.ps1
   - windows/win_user_right.py
+  - windows/win_wait_for.ps1
+  - windows/win_wait_for.py
   - windows/win_whoami.ps1
   - windows/win_whoami.py

--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -3017,8 +3017,6 @@ windows:
   - windows/win_unzip.py
   - windows/win_user_profile.ps1
   - windows/win_user_profile.py
-  - windows/win_wait_for.ps1
-  - windows/win_wait_for.py
   - windows/win_wait_for_process.ps1
   - windows/win_wait_for_process.py
   - windows/win_wakeonlan.ps1


### PR DESCRIPTION
The `wait_for` module is in base and this is used in at least 1 or 2 core Windows tests. This makes sure it is available for all integration tests that may require it.