### PR TITLE
🤖 Configure Boring Cyborg GitHub App

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -1,0 +1,23 @@
+labelPRBasedOnFilePath:
+  BCS:
+  - scenarios/bcs/*
+  mintest:
+  - scenarios/mintest/*
+  NWO:
+  - scenarios/nwo/*
+  migrate:
+  - gh.py
+  - migrate.py
+  - rsa_utils.py
+  - template_utils.py
+  - undolinks.sh
+  CI/CD:
+  - .github/workflows/*.yml
+  templates:
+  - resources/*
+  dependencies:
+  - requirements.in
+  - requirements.txt
+  documentation:
+  - **/*.md
+  - **/*.rst


### PR DESCRIPTION
This configuration enables autolabeling based on the
`.github/boring-cyborg.yml` config file entries.

Refs:
* https://github.com/apps/boring-cyborg
* https://github.com/marketplace/boring-cyborg-add-labels-to-prs-based-on-filepaths
* https://github.com/kaxil/boring-cyborg