### PR TITLE
[NWO] Migrate mariadb_replication tests.

### DIFF
--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -498,6 +498,14 @@ general:
   - scaleway.py
   - virtualbox.py
   - vultr.py
+  integration:
+  - mariadb_replication/tasks/mariadb_replication_initial.yml
+  - mariadb_replication/tasks/mariadb_replication_connection_name.yml
+  - mariadb_replication/tasks/mariadb_master_use_gtid.yml
+  - mariadb_replication/tasks/main.yml
+  - mariadb_replication/meta/main.yml
+  - mariadb_replication/defaults/main.yml
+  - mariadb_replication/aliases
   inventory_scripts:
   - abiquo.ini
   - abiquo.py


### PR DESCRIPTION
The mariadb_replication tests are for the mysql_replication module which is already being migrated to community.general.