### PR TITLE
Fix Boring-Cyborg config

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -19,5 +19,5 @@ labelPRBasedOnFilePath:
   - requirements.in
   - requirements.txt
   documentation:
-  - **/*.md
-  - **/*.rst
+  - "**/*.md"
+  - "**/*.rst"


### PR DESCRIPTION
The YAML file before was not a valid YAML and failed with following error:

```
Error : Reference "*/*.md" does not exist.
Line : - **/*.md  undefined
```

This can be validated by copy-pasting the current config in master to https://codebeautify.org/yaml-validator

![image](https://user-images.githubusercontent.com/8811558/74818395-7bc28700-52f6-11ea-857b-526a9fcc059e.png)


That is mainly because it thinks "**" is a YAML alias as the item starts with "*", wrapping it under strings does the work :)