### PR TITLE
NWO: Add ipaddr filter to ansible.netcommon

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -426,6 +426,7 @@ netcommon:
   - netconf.py
   - network_agnostic.py
   filter:
+  - ipaddr.py
   - network.py
   httpapi:
   - restconf.py

--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -401,7 +401,6 @@ general:
   - zabbix.py
   filter:
   - gcp_kms_filters.py
-  - ipaddr.py
   - json_query.py
   - random_mac.py
   httpapi:


### PR DESCRIPTION
We'd like to promote this out from community.general into
ansible.netcommon.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>