### PR TITLE
[NWO] Promote win_certificate_store to core

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -475,6 +475,8 @@ windows:
   - windows/win_acl.py
   - windows/win_acl_inheritance.ps1
   - windows/win_acl_inheritance.py
+  - windows/win_certificate_store.ps1
+  - windows/win_certificate_store.py
   - windows/win_command.ps1
   - windows/win_command.py
   - windows/win_copy.ps1

--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -2819,8 +2819,6 @@ windows:
   - windows/win_auto_logon.py
   - windows/win_certificate_info.ps1
   - windows/win_certificate_info.py
-  - windows/win_certificate_store.ps1
-  - windows/win_certificate_store.py
   - windows/win_chocolatey.ps1
   - windows/win_chocolatey.py
   - windows/win_chocolatey_config.ps1


### PR DESCRIPTION
The `win_certificate_store` is used by the core Windows collection tests and I think it warrants a promotion to core. Dealing with certs is pretty important in an enterprise environment so having that as core opens makes it more available for those environments.