### PR TITLE
[NWO] Add newly accepted  module `ec2_tag_info` to community.amazon

### DIFF
--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -143,6 +143,7 @@ amazon:
   - cloud/amazon/ecs_service.py
   - cloud/amazon/ecs_service_info.py
   - cloud/amazon/ecs_tag.py
+  - cloud/amazon/ec2_tag_info.py
   - cloud/amazon/ecs_task.py
   - cloud/amazon/ecs_taskdefinition.py
   - cloud/amazon/ecs_taskdefinition_info.py


### PR DESCRIPTION
We've recently added a new amazon module, it should go in the community collection.