### PR TITLE
[NWO] Migrate various contrib to community.general.

### DIFF
--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -429,6 +429,7 @@ general:
   integration:
   - mariadb_replication/*
   - mariadb_replication/*/*
+  - script_inventory_foreman/*
   inventory_scripts:
   - azure_rm.*
   - abiquo.ini

--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -476,6 +476,7 @@ general:
   - nsot.py
   - nsot.yaml
   - openshift.py
+  - openstack*
   - openvz.py
   - ovirt4.py
   - ovirt.ini

--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -430,6 +430,7 @@ general:
   - mariadb_replication/*
   - mariadb_replication/*/*
   inventory_scripts:
+  - azure_rm.*
   - abiquo.ini
   - abiquo.py
   - apache-libcloud.py
@@ -452,7 +453,10 @@ general:
   - docker.py
   - docker.yml
   - fleet.py
+  - foreman.*
   - freeipa.py
+  - gce.*
+  - infoblox.*
   - jail.py
   - landscape.py
   - libcloud.ini
@@ -2565,6 +2569,9 @@ general:
   - slxos.py
   - sros.py
   - voss.py
+  vault:
+  - azure_vault.*
+  - vault-keyring*
 grafana:
   callback:
   - grafana_annotations.py


### PR DESCRIPTION
Since these are scripts instead of plugins they should be migrated to a community collection. Since there isn't a more specific collection for any of these, they should go into `community.general`.