### PR TITLE
[NWO] Migrate vmware contrib to community.vmware.

### DIFF
--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -2627,8 +2627,13 @@ vmware:
   - vmware_rest_client.py
   httpapi:
   - vmware.py
+  integration:
+  - script_inventory_vmware_inventory/*
   inventory:
   - vmware_vm_inventory.py
+  inventory_scripts:
+  - vmware.*
+  - vmware_inventory.*
   module_utils:
   - vca.py
   - vmware.py


### PR DESCRIPTION
Since these are scripts instead of plugins they should be migrated to a community collection. The existing `community.vmware` collection seems appropriate.