### PR TITLE
[NWO] Migrate amazon contrib to community.amazon.

### DIFF
--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -1,6 +1,13 @@
 amazon:
   connection:
   - aws_ssm.py
+  integration:
+  - script_inventory_ec2/*
+  - script_inventory_ec2/*/*
+  - script_inventory_ec2/*/*/*
+  - script_inventory_ec2/*/*/*/*
+  inventory_scripts:
+  - ec2.*
   modules:
   - cloud/amazon/__init__.py
   - cloud/amazon/_aws_acm_facts.py


### PR DESCRIPTION
Since these are scripts instead of plugins they should be migrated to a community collection. The existing `community.amazon` collection seems appropriate.