### PR TITLE
[NWO] Migrate amazon contrib to community.amazon.

### DIFF
--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -1,6 +1,13 @@
 amazon:
   connection:
   - aws_ssm.py
+  integration:
+  - script_inventory_ec2/*
+  - script_inventory_ec2/*/*
+  - script_inventory_ec2/*/*/*
+  - script_inventory_ec2/*/*/*/*
+  inventory_scripts:
+  - ec2.*
   modules:
   - cloud/amazon/__init__.py
   - cloud/amazon/_aws_acm_facts.py


### PR DESCRIPTION
Replaces https://github.com/ansible-community/collection_migration/pull/445 since GitHub is having issues with that PR.