### PR TITLE
NWO: move telnet into ansible.netcommon

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -414,6 +414,7 @@ netcommon:
   - net_*
   - netconf.py
   - network.py
+  - telnet.py
   become:
   - enable.py
   connection:
@@ -437,6 +438,7 @@ netcommon:
   - network/netconf/*
   - network/restconf/*
   modules:
+  - commands/telnet.py
   - network/cli/*
   - network/files/*
   - network/interface/*

--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -243,7 +243,6 @@ general:
   - slxos.py
   - sros.py
   - synchronize.py
-  - telnet.py
   - voss.py
   become:
   - doas.py
@@ -1411,7 +1410,6 @@ general:
   - clustering/pacemaker_cluster.py
   - clustering/znode.py
   - commands/__init__.py
-  - commands/telnet.py
   - crypto/__init__.py
   - crypto/acme/__init__.py
   - crypto/acme/_acme_account_facts.py


### PR DESCRIPTION
Rather this being in community, we'll move into ansible.netcommon and
support via the network team.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>