### PR TITLE
[NWO] win_psrepository_info

### DIFF
--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -2926,6 +2926,8 @@ windows:
   - windows/win_psmodule.py
   - windows/win_psrepository.ps1
   - windows/win_psrepository.py
+  - windows/win_psrepository_info.ps1
+  - windows/win_psrepository_info.py
   - windows/win_rabbitmq_plugin.ps1
   - windows/win_rabbitmq_plugin.py
   - windows/win_rds_cap.ps1


### PR DESCRIPTION
Module was recently merge with https://github.com/ansible/ansible/pull/67594, just adding it's migration path to the community.windows collection.