### PR TITLE
[NWO] AWS scenario changes

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -63,6 +63,7 @@ amazon:
   - cloud/amazon/ec2_snapshot.py
   - cloud/amazon/ec2_snapshot_info.py
   - cloud/amazon/ec2_tag.py
+  - cloud/amazon/ec2_tag_info.py
   - cloud/amazon/ec2_vol.py
   - cloud/amazon/ec2_vol_info.py
   - cloud/amazon/ec2_vpc_dhcp_option.py

--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -44,7 +44,6 @@ amazon:
   - cloud/amazon/_ec2_vpc_dhcp_option_facts.py
   - cloud/amazon/_ec2_vpc_net_facts.py
   - cloud/amazon/_ec2_vpc_subnet_facts.py
-  - cloud/amazon/_ec2_vpc_route_table_facts.py
   - cloud/amazon/aws_az_info.py
   - cloud/amazon/aws_caller_info.py
   - cloud/amazon/aws_s3.py
@@ -72,8 +71,6 @@ amazon:
   - cloud/amazon/ec2_vpc_net_info.py
   - cloud/amazon/ec2_vpc_subnet.py
   - cloud/amazon/ec2_vpc_subnet_info.py
-  - cloud/amazon/ec2_vpc_route_table.py
-  - cloud/amazon/ec2_vpc_route_table_info.py
   - cloud/amazon/s3_bucket.py
 
 _core:

--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -150,7 +150,6 @@ amazon:
   - cloud/amazon/ecs_service.py
   - cloud/amazon/ecs_service_info.py
   - cloud/amazon/ecs_tag.py
-  - cloud/amazon/ec2_tag_info.py
   - cloud/amazon/ecs_task.py
   - cloud/amazon/ecs_taskdefinition.py
   - cloud/amazon/ecs_taskdefinition_info.py

--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -30,6 +30,7 @@ amazon:
   - cloud/amazon/_ec2_vpc_nacl_facts.py
   - cloud/amazon/_ec2_vpc_nat_gateway_facts.py
   - cloud/amazon/_ec2_vpc_peering_facts.py
+  - cloud/amazon/_ec2_vpc_route_table_facts.py
   - cloud/amazon/_ec2_vpc_vgw_facts.py
   - cloud/amazon/_ec2_vpc_vpn_facts.py
   - cloud/amazon/_ecs_service_facts.py
@@ -91,6 +92,7 @@ amazon:
   - cloud/amazon/aws_waf_rule.py
   - cloud/amazon/aws_waf_web_acl.py
   - cloud/amazon/cloudformation_stack_set.py
+  - cloud/amazon/cloudformation_exports_info.py
   - cloud/amazon/cloudfront_distribution.py
   - cloud/amazon/cloudfront_info.py
   - cloud/amazon/cloudfront_invalidation.py
@@ -139,6 +141,8 @@ amazon:
   - cloud/amazon/ec2_vpc_nat_gateway_info.py
   - cloud/amazon/ec2_vpc_peer.py
   - cloud/amazon/ec2_vpc_peering_info.py
+  - cloud/amazon/ec2_vpc_route_table.py
+  - cloud/amazon/ec2_vpc_route_table_info.py
   - cloud/amazon/ec2_vpc_vgw.py
   - cloud/amazon/ec2_vpc_vgw_info.py
   - cloud/amazon/ec2_vpc_vpn.py


### PR DESCRIPTION
I erred, ec2_tag_info needs to be core because shared tests with ec2_tag which is being promoted.
Depromote things to community that we're not actually taking; these were ec2_instance dependencies and we ended up not promoting ec2_instance.
Add new module cloudformation_exports_info