### PR TITLE
NWO: Add missing __init__.py for files folder

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -319,6 +319,7 @@ _core:
   - commands/raw.py
   - commands/script.py
   - commands/shell.py
+  - files/__init__.py
   - files/blockinfile.py
   - files/copy.py
   - files/fetch.py


### PR DESCRIPTION
This should fix:

  ERROR! couldn't resolve module/action 'find'. This often indicates a
  misspelling, missing collection, or incorrect module path.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>