### PR TITLE
NWO - Keep runas become plugin in base

### DIFF
--- a/scenarios/nwo/ansible.yml
+++ b/scenarios/nwo/ansible.yml
@@ -107,6 +107,7 @@ _core:
   - yum.py
   become:
   - __init__.py
+  - runas.py
   - su.py
   - sudo.py
   cache:
@@ -485,8 +486,6 @@ windows:
   - win_reboot.py
   - win_template.py
   - win_updates.py
-  become:
-  - runas.py
   doc_fragments:
   - url_windows.py
   integration:


### PR DESCRIPTION
The [runas](https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/become/runas.py) become plugin is not like other become plugins where it wraps a command line call. The actual implementation is part of the subsystem exec and put in the module wrapper. All this code is in `ansible-base` and it makes no sense to have the documentation for that code live in another location.