### PR TITLE
community.crypto: enable module subdirectories

### DIFF
--- a/scenarios/nwo/community.yml
+++ b/scenarios/nwo/community.yml
@@ -2276,6 +2276,8 @@ kubernetes:
   - clustering/openshift/_openshift_raw.py
   - clustering/openshift/_openshift_scale.py
 crypto:
+  _options:
+    flatmap: True
   modules:
     - crypto/*
     - crypto/*/*


### PR DESCRIPTION
As mentioned in #ansible-devel.

CC @gundalow 