### PR TITLE
updated cisco ucs modules

### DIFF
--- a/scenarios/nwo/cisco.yml
+++ b/scenarios/nwo/cisco.yml
@@ -231,10 +231,24 @@ ucs:
   module_utils:
   - remote_management/ucs.py
   modules:
-  - remote_management/ucs/ucs_ip_pool.py
-  - remote_management/ucs/ucs_mac_pool.py
-  - remote_management/ucs/ucs_managed_objects.py
-  - remote_management/ucs/ucs_query.py
-  - remote_management/ucs/ucs_service_profile_template.py
-  - remote_management/ucs/ucs_uuid_pool.py
-  - remote_management/ucs/ucs_vlans.py
+  - ucs_disk_group_policy.py
+  - ucs_dns_server.py
+  - ucs_ip_pool.py
+  - ucs_lan_connectivity.py
+  - ucs_mac_pool.py
+  - ucs_managed_objects.py
+  - ucs_ntp_server.py
+  - ucs_org.py
+  - ucs_query.py
+  - ucs_san_connectivity.py
+  - ucs_service_profile_from_template.py
+  - ucs_service_profile_template.py
+  - ucs_storage_profile.py
+  - ucs_timezone.py
+  - ucs_uuid_pool.py
+  - ucs_vhba_template.py
+  - ucs_vlan_find.py
+  - ucs_vlans.py
+  - ucs_vnic_template.py
+  - ucs_vsans.py
+  - ucs_wwn_pool.py

--- a/scenarios/nwo/cisco.yml
+++ b/scenarios/nwo/cisco.yml
@@ -231,24 +231,24 @@ ucs:
   module_utils:
   - remote_management/ucs.py
   modules:
-  - ucs_disk_group_policy.py
-  - ucs_dns_server.py
-  - ucs_ip_pool.py
-  - ucs_lan_connectivity.py
-  - ucs_mac_pool.py
-  - ucs_managed_objects.py
-  - ucs_ntp_server.py
-  - ucs_org.py
-  - ucs_query.py
-  - ucs_san_connectivity.py
-  - ucs_service_profile_from_template.py
-  - ucs_service_profile_template.py
-  - ucs_storage_profile.py
-  - ucs_timezone.py
-  - ucs_uuid_pool.py
-  - ucs_vhba_template.py
-  - ucs_vlan_find.py
-  - ucs_vlans.py
-  - ucs_vnic_template.py
-  - ucs_vsans.py
-  - ucs_wwn_pool.py
+  - remote_management/ucs/ucs_disk_group_policy.py
+  - remote_management/ucs/ucs_dns_server.py
+  - remote_management/ucs/ucs_ip_pool.py
+  - remote_management/ucs/ucs_lan_connectivity.py
+  - remote_management/ucs/ucs_mac_pool.py
+  - remote_management/ucs/ucs_managed_objects.py
+  - remote_management/ucs/ucs_ntp_server.py
+  - remote_management/ucs/ucs_org.py
+  - remote_management/ucs/ucs_query.py
+  - remote_management/ucs/ucs_san_connectivity.py
+  - remote_management/ucs/ucs_service_profile_from_template.py
+  - remote_management/ucs/ucs_service_profile_template.py
+  - remote_management/ucs/ucs_storage_profile.py
+  - remote_management/ucs/ucs_timezone.py
+  - remote_management/ucs/ucs_uuid_pool.py
+  - remote_management/ucs/ucs_vhba_template.py
+  - remote_management/ucs/ucs_vlan_find.py
+  - remote_management/ucs/ucs_vlans.py
+  - remote_management/ucs/ucs_vnic_template.py
+  - remote_management/ucs/ucs_vsans.py
+  - remote_management/ucs/ucs_wwn_pool.py

--- a/scenarios/nwo/cisco.yml
+++ b/scenarios/nwo/cisco.yml
@@ -239,9 +239,7 @@ ucs:
   - remote_management/ucs/ucs_managed_objects.py
   - remote_management/ucs/ucs_ntp_server.py
   - remote_management/ucs/ucs_org.py
-  - remote_management/ucs/ucs_query.py
   - remote_management/ucs/ucs_san_connectivity.py
-  - remote_management/ucs/ucs_service_profile_from_template.py
   - remote_management/ucs/ucs_service_profile_template.py
   - remote_management/ucs/ucs_storage_profile.py
   - remote_management/ucs/ucs_timezone.py


### PR DESCRIPTION
Complete Cisco UCS module list in the cisco.ucs collection as of March 5th 2020

ucs_disk_group_policy.py
ucs_dns_server.py
ucs_ip_pool.py
ucs_lan_connectivity.py
ucs_mac_pool.py
ucs_managed_objects.py
ucs_ntp_server.py
ucs_org.py
ucs_query.py
ucs_san_connectivity.py
ucs_service_profile_from_template.py
ucs_service_profile_template.py
ucs_storage_profile.py
ucs_timezone.py
ucs_uuid_pool.py
ucs_vhba_template.py
ucs_vlan_find.py
ucs_vlans.py
ucs_vnic_template.py
ucs_vsans.py
ucs_wwn_pool.py